### PR TITLE
fix: update old repo urls

### DIFF
--- a/frameworks/express/package.json
+++ b/frameworks/express/package.json
@@ -11,14 +11,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/opticdev/optic-express.git"
+    "url": "git+https://github.com/opticdev/optic-node.git"
   },
   "author": "Mike Elsmore <mike.elsmore@useoptic.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/opticdev/optic-express/issues"
+    "url": "https://github.com/opticdev/optic-node/issues"
   },
-  "homepage": "https://github.com/opticdev/optic-express#readme",
+  "homepage": "https://github.com/opticdev/optic-node#readme",
   "devDependencies": {
     "@types/body-parser": "^1.19.0",
     "@types/command-exists": "^1.2.0",

--- a/frameworks/hapi/package.json
+++ b/frameworks/hapi/package.json
@@ -11,14 +11,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/opticdev/optic-express.git"
+    "url": "git+https://github.com/opticdev/optic-node.git"
   },
   "author": "Mike Elsmore <mike.elsmore@useoptic.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/opticdev/optic-express/issues"
+    "url": "https://github.com/opticdev/optic-node/issues"
   },
-  "homepage": "https://github.com/opticdev/optic-express#readme",
+  "homepage": "https://github.com/opticdev/optic-node#readme",
   "devDependencies": {
     "@types/body-parser": "^1.19.0",
     "@types/command-exists": "^1.2.0",


### PR DESCRIPTION
closes https://github.com/opticdev/optic-node/issues/2