### PR TITLE
fix: framework packages should build sdk first

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ NodeJS middlewares for using Optic within [ExpressJS](https://expressjs.com) and
 1. Push your tags, `git push origin main --tags`
 1. Confirm the GHA completes and the new version is published.
 
-Note: The above is currently broken, see https://github.com/opticdev/optic-node/issues/9. For now, stick to the manual publishing steps.
-
 # Publishing manually
+
+Note: Consider publishing through CI :)
 
 0. Have an NPM publish token for the packages to publish
 0. Before merging your PR set the desired version in the respective package.json(s)

--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 NodeJS middlewares for using Optic within [ExpressJS](https://expressjs.com) and [hapi](https://hapi.dev).
 
-# Publishing via CI
+## Publishing via CI
 
-1. Before merging your PR set the desired version in the respective package.json(s)
-1. After merging your PR to the default branch, tag which package(s) should be published, e.g., `git tag express/v0.0.1`. Note the tag must match the pattern in the corresponding `publish-*.yml` GitHub Action workflow to trigger publishing (`sdk/*`, `express/*`, `hapi/*`)
+1. Before merging your PR, set the desired version in the respective package.json(s)
+1. After merging your PR to the default branch, tag which package(s) should be published, e.g., `git tag express/v0.0.1`. Note the tag must match the pattern in the corresponding `publish-*.yml` GitHub Action workflow to trigger publishing (`sdk/*`, `express/*`, `hapi/*`).
 1. Push your tags, `git push origin main --tags`
 1. Confirm the GHA completes and the new version is published.
 
-# Publishing manually
+Step 2 & 3 can be simplified using, `task git:tag-and-push -- express/v0.0.1`. Run this once for each tag you intend to create.
+
+## Publishing manually
 
 Note: Consider publishing through CI :)
 
@@ -23,3 +25,10 @@ Note: Consider publishing through CI :)
     * sdk:publish:          Publish @useoptic/optic-node-sdk
     ```
     By default, the publish task will default to DRY_RUN=true and display the package and version that would be published.
+
+## Removing a tag
+
+```
+git tag -d -- <the tag>
+git push origin -- :refs/tags/<the tag>
+```

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,7 +31,7 @@ tasks:
     desc: Build the Extress middleware
     dir: frameworks/express
     deps:
-      - task: sdk:build
+      - sdk:build
     cmds:
       - yarn build
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -31,7 +31,7 @@ tasks:
     desc: Build the Extress middleware
     dir: frameworks/express
     deps:
-      - task: yarn:install
+      - task: sdk:build
     cmds:
       - yarn build
 
@@ -55,7 +55,7 @@ tasks:
     desc: Build the Extress middleware
     dir: frameworks/hapi
     deps:
-      - task: yarn:install
+      - sdk:build
     cmds:
       - yarn build
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -105,6 +105,12 @@ tasks:
         vars:
           PROJECT_DIR: "{{.PROJECT_DIR}}"
 
+  git:tag-and-push:
+    - git co main
+    - git pull --rebase
+    - git tag {{.CLI_ARGS}}
+    - git push origin main --tags
+
   #
   # composite tasks
   #

--- a/package.json
+++ b/package.json
@@ -1,4 +1,11 @@
 {
   "private": true,
-  "workspaces": ["sdk", "frameworks/express", "frameworks/hapi"]
+  "workspaces": [
+    "sdk",
+    "frameworks/express",
+    "frameworks/hapi"
+  ],
+  "scripts": {
+    "clean": "find . -maxdepth 3 -type d -name dist | xargs rm -rf && find . -maxdepth 3 -type d -name node_modules | xargs rm -rf"
+  }
 }


### PR DESCRIPTION
explained in and closes https://github.com/opticdev/optic-node/issues/9. the repro case works now,
```
➜ docker run -it --rm --volume=(pwd):/app node:alpine ash
/ # cd /app && \
> yarn install && \
> cd sdk && \
> yarn build && \
> cd ../frameworks/express-middleware && \
> yarn build
...
