### PR TITLE
Change how the plugin/middleware is exported

### DIFF
--- a/frameworks/express/README.md
+++ b/frameworks/express/README.md
@@ -12,7 +12,7 @@ The module requires `@useoptic/cli` to be installed, instructions on installing 
 
 It also requires something like [`body-parser`](https://www.npmjs.com/package/body-parser) to be used as part of the middleware stack to access the body of the HTTP requests within Express
 
-## Intsall
+## Install
 
 ```sh
 npm install @useoptic/express-middleware
@@ -38,13 +38,13 @@ Using a basic [Express](https://expressjs.com/) server proxying to [httpbin](htt
 const express = require('express')
 const bodyParser = require('body-parser')
 const { createProxyMiddleware } = require('http-proxy-middleware');
-const optic = require('@useoptic/express-middleware');
+const { OpticMiddleware } = require('@useoptic/express-middleware');
 
 const app = express()
 const port = 3000
 
 app.use(bodyParser())
-app.use(optic({
+app.use(OpticMiddleware({
     enabled: true,
 }))
 

--- a/frameworks/express/example/index.js
+++ b/frameworks/express/example/index.js
@@ -1,20 +1,18 @@
 const express = require('express')
-const http = require('http')
 const bodyParser = require('body-parser')
-const { createProxyMiddleware } = require('http-proxy-middleware');
-const optic = require('../').default;
+const { createProxyMiddleware } = require('http-proxy-middleware')
+const { OpticMiddleware } = require('../')
 const app = express()
 const port = 3000
 
 app.use(bodyParser())
 
-app.use(optic({
-    console: true,
-    log: true,
-    enabled: true,
+app.use(OpticMiddleware({
+  console: true,
+  enabled: true
 }))
 
-app.use('/', createProxyMiddleware({ target: 'https://httpbin.org', changeOrigin: true }));
+app.use('/', createProxyMiddleware({ target: 'https://httpbin.org', changeOrigin: true }))
 
 app.listen(port, () => {
   console.log(`Example app listening at http://localhost:${port}`)

--- a/frameworks/express/package.json
+++ b/frameworks/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/express-middleware",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "NodeJS middleware for using Optic within ExpressJS",
   "main": "./dist/index.js",
   "scripts": {
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@elastic/ecs-helpers": "^1.1.0",
-    "@useoptic/optic-node-sdk": "0.0.4",
+    "@useoptic/optic-node-sdk": "^0.0.5",
     "debug": "^4.3.1"
   },
   "peerDependencies": {

--- a/frameworks/express/src/index.ts
+++ b/frameworks/express/src/index.ts
@@ -10,7 +10,7 @@ interface Options {
     uploadUrl?: string,
 }
 
-export default (options: Options) => {
+const ExpressOpticMiddleware = (options: Options) => {
   logger.log('Optic middleware loaded')
   return async (req: express.Request, res: express.Response, next: express.NextFunction) => {
     try {
@@ -45,3 +45,6 @@ export default (options: Options) => {
     }
   }
 }
+
+export const OpticMiddleware = ExpressOpticMiddleware
+export default ExpressOpticMiddleware

--- a/frameworks/hapi/README.md
+++ b/frameworks/hapi/README.md
@@ -10,7 +10,7 @@ This module is an [hapi](https://hapi.dev/) plugin using [@useoptic/optic-node-s
 
 The module requires `@useoptic/cli` to be installed, instructions on installing it are available [https://www.useoptic.com/docs/](https://www.useoptic.com/docs/).
 
-## Intsall
+## Install
 
 ```sh
 npm install @useoptic/hapi-middleware
@@ -34,7 +34,7 @@ Using a basic [hapi](https://hapi.dev/) server.
 
 ```js
 const Hapi = require('@hapi/hapi')
-const Optic = require('@useoptic/hapi-middleware')
+const { OpticPlugin } = require('@useoptic/hapi-middleware')
 
 const init = async () => {
   const server = Hapi.server({
@@ -43,7 +43,7 @@ const init = async () => {
   })
 
   await server.register({
-    plugin: Optic,
+    plugin: OpticPlugin,
     options: {
       enabled: true
     }

--- a/frameworks/hapi/example/index.js
+++ b/frameworks/hapi/example/index.js
@@ -1,39 +1,37 @@
-const Hapi = require('@hapi/hapi');
-const Optic = require('../').default;
+const Hapi = require('@hapi/hapi')
+const { OpticPlugin } = require('../')
 
 const init = async () => {
+  const server = Hapi.server({
+    port: 3001,
+    host: 'localhost'
+  })
 
-    const server = Hapi.server({
-        port: 3001,
-        host: 'localhost'
-    });
+  await server.register({
+    plugin: OpticPlugin,
+    options: {
+      console: true,
+      enabled: true
+    }
+  })
+  server.route({
+    method: ['GET', 'POST'],
+    path: '/',
+    handler: (request, h) => {
+      return 'Hello World!' + Math.random()
+    }
+  })
 
-    await server.register({
-        plugin: Optic,
-        options: {
-            console: true,
-            local: true
-        }
-    });
-    server.route({
-        method: ['GET', 'POST'],
-        path: '/',
-        handler: (request, h) => {
-
-            return 'Hello World!' + Math.random();
-        }
-    });
-
-    await server.start();
-    console.log('Server running on %s', server.info.uri);
-};
+  await server.start()
+  console.log('Server running on %s', server.info.uri)
+}
 
 process.on('unhandledRejection', (err) => {
-    if(err){
-        console.log('ERROR')
-        console.log(err);
-        process.exit(1);
-}
-});
+  if (err) {
+    console.log('ERROR')
+    console.log(err)
+    process.exit(1)
+  }
+})
 
-init();
+init()

--- a/frameworks/hapi/package.json
+++ b/frameworks/hapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/hapi-middleware",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "NodeJS middleware for using Optic within Hapi",
   "main": "./dist/index.js",
   "scripts": {
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@elastic/ecs-helpers": "^1.1.0",
-    "@useoptic/optic-node-sdk": "0.0.4",
+    "@useoptic/optic-node-sdk": "^0.0.5",
     "debug": "^4.3.1"
   },
   "peerDependencies": {

--- a/frameworks/hapi/src/index.ts
+++ b/frameworks/hapi/src/index.ts
@@ -9,7 +9,7 @@ interface IOptions {
   uploadUrl?: string,
 }
 
-export default {
+const HapiOpticPlugin = {
   register: (server: Hapi.Server, options: IOptions) => {
     logger.log('Optic plugin loaded')
     const optic = new Optic({
@@ -31,3 +31,6 @@ export default {
   },
   pkg: require('../package.json')
 }
+
+export const OpticPlugin = HapiOpticPlugin
+export default HapiOpticPlugin

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@useoptic/optic-node-sdk",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Send data to Optic from JS",
   "main": "./dist/index.js",
   "scripts": {

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -20,7 +20,7 @@ export default class Optic {
   protected config: IOptions;
   private userAgent: string;
 
-  constructor(options: IOptions) {
+  constructor (options: IOptions) {
     this.config = {}
     this.config.enabled = options.enabled || false
     this.config.uploadUrl = options.uploadUrl || (process.env.OPTIC_LOGGING_URL ? process.env.OPTIC_LOGGING_URL + 'ecs' : '')
@@ -29,12 +29,12 @@ export default class Optic {
     this.userAgent = this.buildUserAgent(options.framework)
   }
 
-  buildUserAgent(framework?: string): string {
-    return getUserAgent() + ((framework) ? framework : '')
+  buildUserAgent (framework?: string): string {
+    return getUserAgent() + ((framework) ? ' ' + framework : '')
   }
 
   // @TODO use tag for user agent
-  static formatObject(req: any, res: any, hydrate?: IHydrateBody) {
+  static formatObject (req: any, res: any, hydrate?: IHydrateBody) {
     const httpObj = {
       http: {
         response: {},
@@ -57,35 +57,35 @@ export default class Optic {
     return httpObj
   }
 
-  sendToConsole(obj: any) {
+  sendToConsole (obj: any) {
     if (this.config.console) {
       logger.log('Optic logging to terminal')
       console.log(JSON.stringify(obj))
     }
   }
 
-  async sendToUrl(obj: any) {
+  async sendToUrl (obj: any) {
     logger.log('Optic logging to @useoptic/cli')
     try {
       logger.log(`Uploading to ${this.config.uploadUrl}`)
       fetch(String(this.config.uploadUrl), {
         method: 'post',
         body: JSON.stringify([obj]),
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' }
       })
     } catch (error) {
       logger.error(error)
     }
   }
 
-  captureHttpRequest(req: any, res: any, hydrate?: IHydrateBody): void {
+  captureHttpRequest (req: any, res: any, hydrate?: IHydrateBody): void {
     if (this.config.enabled) {
       logger.log('Optic logging request')
       const httpObj = Optic.formatObject(req, res, hydrate)
       // Add optic information
-      httpObj.optic = {
-        user: this.userAgent,
-      }
+      // httpObj.optic = {
+      //   agent: this.userAgent
+      // }
       if (this.config.console) this.sendToConsole(httpObj)
       if (this.config.uploadUrl) this.sendToUrl(httpObj)
     }


### PR DESCRIPTION
A run through pointed out the ugly use of `.default`, this is to remove that as `esModuleInterop` in `tsconfig.json` is already set and doesn't fix it (https://github.com/opticdev/optic-node/blob/main/frameworks/express/tsconfig.json#L53)

Also removing a field that is possibly failing on the capture side temporarily